### PR TITLE
Remove Data directory creation and permission setting from Dockerfile

### DIFF
--- a/CptcEvents/Dockerfile
+++ b/CptcEvents/Dockerfile
@@ -13,7 +13,4 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:eaa79205c3ade4792a7f7bf310a3aac
 WORKDIR /App
 COPY --from=build /App/out .
 
-# Create Data directory for SQLite database with proper permissions
-RUN mkdir -p /App/Data && chmod 777 /App/Data
-
 ENTRYPOINT ["dotnet", "CptcEvents.dll"]


### PR DESCRIPTION
This pull request makes a minor change to the `CptcEvents/Dockerfile` by removing the step that creates the `Data` directory and sets its permissions. This means the Docker image will no longer explicitly create the `/App/Data` directory or set its permissions during build.